### PR TITLE
numexpr: no local_dict.clear() on Python 3.13

### DIFF
--- a/src/awkward/_connect/numexpr.py
+++ b/src/awkward/_connect/numexpr.py
@@ -66,7 +66,7 @@ def getArguments(names, local_dict=None, global_dict=None):
                 a = global_dict[name]
             arguments.append(a)  # <--- different from NumExpr
     finally:
-        if clear_local_dict:
+        if clear_local_dict and hasattr(local_dict, 'clear'):
             local_dict.clear()
 
     return arguments


### PR DESCRIPTION
Compare https://github.com/pydata/numexpr/issues/488 / https://github.com/pydata/numexpr/pull/489

Fixes a test suite error on Python 3.13:

```python
[   89s] _________________________________ test_numexpr _________________________________
[   89s] [gw4] linux -- Python 3.13.2 /usr/bin/python3.13
[   89s]
[   89s]     def test_numexpr():
[   89s]         # NumExpr's interface pulls variables from the surrounding scope,
[   89s]         # so these F841 "unused variables" actually are used.
[   89s]
[   89s]         a = ak.Array([[1.1, 2.2, 3.3], [], [4.4, 5.5]], check_valid=True)
[   89s]         b = ak.Array([100, 200, 300], check_valid=True)  # noqa: F841
[   89s] >       assert to_list(ak._connect.numexpr.evaluate("a + b")) == [
[   89s]             [101.1, 102.2, 103.3],
[   89s]             [],
[   89s]             [304.4, 305.5],
[   89s]         ]
[   89s]
[   89s] a          = <Array [[1.1, 2.2, 3.3], [], [4.4, 5.5]] type='3 * var * float64'>
[   89s] b          = <Array [100, 200, 300] type='3 * int64'>
[   89s]
[   89s] tests/test_0119_numexpr_and_broadcast_arrays.py:31:
[   89s] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
[   89s] /usr/lib/python3.13/site-packages/awkward/_connect/numexpr.py:87: in evaluate
[   89s]     arguments = getArguments(names, local_dict, global_dict)
[   89s]         casting    = 'safe'
[   89s]         context    = {'optimization': 'aggressive', 'truediv': False}
[   89s]         ex_uses_vml = False
[   89s]         expr_key   = ('a + b', (('optimization', 'aggressive'), ('truediv', False)))
[   89s]         expression = 'a + b'
[   89s]         global_dict = None
[   89s]         kwargs     = {}
[   89s]         local_dict = None
[   89s]         names      = ['a', 'b']
[   89s]         numexpr    = <module 'numexpr' from '/usr/lib64/python3.13/site-packages/numexpr/__init__.py'>
[   89s]         order      = 'K'
[   89s] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
[   89s]
[   89s] names = ['a', 'b']
[   89s] local_dict = {'a': <Array [[1.1, 2.2, 3.3], [], [4.4, 5.5]] type='3 * var * float64'>, 'b': <Array [100, 200, 300] type='3 * int64'...e-packages/awkward/_connect/numexpr.py'>, '@py_assert6': <function evaluate at 0x7f98fd2554e0>, '@py_assert8': 'a + b'}
[   89s] global_dict = {'@py_builtins': <module 'builtins' (built-in)>, '@pytest_ar': <module '_pytest.assertion.rewrite' from '/usr/lib/pyth...-awkward-test-2.7.4-build/awkward-2.7.4/tests/__pycache__/test_0119_numexpr_and_broadcast_arrays.cpython-313.pyc', ...}
[   89s]
[   89s]     def getArguments(names, local_dict=None, global_dict=None):
[   89s]         call_frame = sys._getframe(2)
[   89s]
[   89s]         clear_local_dict = False
[   89s]         if local_dict is None:
[   89s]             local_dict = call_frame.f_locals
[   89s]             clear_local_dict = True
[   89s]         try:
[   89s]             frame_globals = call_frame.f_globals
[   89s]             if global_dict is None:
[   89s]                 global_dict = frame_globals
[   89s]
[   89s]             clear_local_dict = clear_local_dict and frame_globals is not local_dict
[   89s]
[   89s]             arguments = []
[   89s]             for name in names:
[   89s]                 try:
[   89s]                     a = local_dict[name]
[   89s]                 except KeyError:
[   89s]                     a = global_dict[name]
[   89s]                 arguments.append(a)  # <--- different from NumExpr
[   89s]         finally:
[   89s]             if clear_local_dict:
[   89s] >               local_dict.clear()
[   89s] E               AttributeError: 'FrameLocalsProxy' object has no attribute 'clear'
[   89s]
[   89s] a          = <Array [100, 200, 300] type='3 * int64'>
[   89s] arguments  = [<Array [[1.1, 2.2, 3.3], [], [4.4, 5.5]] type='3 * var * float64'>, <Array [100, 200, 300] type='3 * int64'>]
[   89s] call_frame = <frame at 0x7f98e370f400, file '/home/abuild/rpmbuild/BUILD/python-awkward-test-2.7.4-build/awkward-2.7.4/tests/test_0119_numexpr_and_broadcast_arrays.py', line 31, code test_numexpr>
[   89s] clear_local_dict = True
[   89s] frame_globals = {'@py_builtins': <module 'builtins' (built-in)>, '@pytest_ar': <module '_pytest.assertion.rewrite' from '/usr/lib/pyth...-awkward-test-2.7.4-build/awkward-2.7.4/tests/__pycache__/test_0119_numexpr_and_broadcast_arrays.cpython-313.pyc', ...}
[   89s] global_dict = {'@py_builtins': <module 'builtins' (built-in)>, '@pytest_ar': <module '_pytest.assertion.rewrite' from '/usr/lib/pyth...-awkward-test-2.7.4-build/awkward-2.7.4/tests/__pycache__/test_0119_numexpr_and_broadcast_arrays.cpython-313.pyc', ...}
[   89s] local_dict = {'a': <Array [[1.1, 2.2, 3.3], [], [4.4, 5.5]] type='3 * var * float64'>, 'b': <Array [100, 200, 300] type='3 * int64'...e-packages/awkward/_connect/numexpr.py'>, '@py_assert6': <function evaluate at 0x7f98fd2554e0>, '@py_assert8': 'a + b'}
[   89s] name       = 'b'
[   89s] names      = ['a', 'b']
[   89s]
[   89s] /usr/lib/python3.13/site-packages/awkward/_connect/numexpr.py:70: AttributeError
```

